### PR TITLE
Build static clui.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ su cland << EOF
 
     # Build
     cd $cland_root_dir/web/clui
-    go build
+    CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"'
 EOF
 
 }


### PR DESCRIPTION
Build static clui to fix glibc 'not found' problem when starting hypercube.

Signed-off-by: xieqiang2020 <xieqiang@cn.ibm.com>